### PR TITLE
feat: add route-level skeleton UIs with Shadcn for improved UX

### DIFF
--- a/src/app/(main)/all_fields/loading.tsx
+++ b/src/app/(main)/all_fields/loading.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+const AllFieldLoading = () => {
+  return (
+    <div className="mx-8 mt-14 overflow-hidden sm:mx-32">
+      <div className="flex max-w-2xl flex-col gap-3 sm:flex-row">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full sm:w-1/3" />
+      </div>
+
+      <div className="mt-20 flex w-full max-w-2xl flex-col gap-4 overflow-hidden lg:flex-row lg:flex-wrap lg:gap-x-7 lg:gap-y-4">
+        {Array(12)
+          .fill(null)
+          .map((_, index) => (
+            <Skeleton
+              key={index}
+              className="h-14 w-full lg:w-[calc(33%-1.5rem)]"
+            />
+          ))}
+      </div>
+    </div>
+  );
+};
+
+export default AllFieldLoading;

--- a/src/app/(main)/collections/loading.tsx
+++ b/src/app/(main)/collections/loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+const CollectionLoading = () => {
+  return (
+    <div>
+      <div className="mx-8 mt-14 flex flex-col gap-3 sm:mx-14 sm:flex-row lg:mx-40 lg:max-w-2xl">
+        <Skeleton className="h-14 w-full" />
+        <Skeleton className="h-14 w-full sm:w-1/3" />
+      </div>
+
+      <div className="mx-8 mt-20 flex flex-col gap-5 sm:mx-14 lg:mx-40 lg:max-w-2xl">
+        {Array(5)
+          .fill(null)
+          .map((_, index) => (
+            <Skeleton key={index} className="h-36 w-full" />
+          ))}
+      </div>
+    </div>
+  );
+};
+
+export default CollectionLoading;

--- a/src/app/(main)/leaderboard/loading.tsx
+++ b/src/app/(main)/leaderboard/loading.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import React from "react";
+
+const LeaderBoardloading = () => {
+  return (
+    <div className="mx-8 mt-12 overflow-hidden lg:mx-32">
+      <Skeleton className="h-12 w-full max-w-3xl" />
+
+      <div className="mt-28 flex w-full max-w-3xl flex-wrap gap-5 overflow-hidden">
+        {Array(8)
+          .fill(null)
+          .map((_, index) => (
+            <Skeleton
+              key={index}
+              className="h-40 w-[calc(50%-1rem)] lg:w-[calc(25%-1rem)]"
+            />
+          ))}
+      </div>
+    </div>
+  );
+};
+
+export default LeaderBoardloading;

--- a/src/app/(main)/loading.tsx
+++ b/src/app/(main)/loading.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div>
+      <Skeleton className="h-80 w-full max-w-5xl sm:h-72" />
+
+      <div className="mx-8 mt-14 flex flex-col gap-3 sm:mx-14 sm:flex-row lg:mx-40 lg:max-w-2xl">
+        <Skeleton className="h-14 w-full" />
+        <Skeleton className="h-14 w-full sm:w-1/3" />
+      </div>
+
+      <div className="mx-8 mt-20 flex flex-col gap-5 sm:mx-14 lg:mx-40 lg:max-w-2xl">
+        {Array.from({ length: 5 }, () => null).map((_, index) => (
+          <Skeleton key={index} className="h-36 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/posts/[id]/loading.tsx
+++ b/src/app/(main)/posts/[id]/loading.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import React from "react";
+
+const PostDetailloading = () => {
+  return (
+    <div className="max-w-5xl p-10">
+      <main className="mt-5 w-full">
+        <div className="flex w-64 gap-4">
+          <Skeleton className="h-10 w-1/2" />
+          <Skeleton className="h-10 w-1/2" />
+        </div>
+
+        <Skeleton className="mt-5 h-10 w-4/5" />
+        <div className="mt-5 flex gap-5">
+          <Skeleton className="size-7 rounded-full" />
+          <Skeleton className="h-7 w-40" />
+        </div>
+
+        <div>
+          <Skeleton className="mt-5 h-10 w-4/5" />
+          <Skeleton className="mt-5 h-10 w-4/5" />
+          <Skeleton className="mt-5 h-10 w-4/5" />
+          <Skeleton className="mt-5 h-10 w-1/5" />
+        </div>
+      </main>
+
+      <section className="mt-10 flex w-full flex-col gap-y-5">
+        {Array(3)
+          .fill(null)
+          .map((_, index) => (
+            <Skeleton key={index} className="h-40 w-full" />
+          ))}
+      </section>
+    </div>
+  );
+};
+
+export default PostDetailloading;

--- a/src/app/(main)/profile/[id]/loading.tsx
+++ b/src/app/(main)/profile/[id]/loading.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import React from "react";
+
+const ProfileLoading = () => {
+  return (
+    <div className="mx-8 lg:mx-12 lg:flex">
+      <section className="mt-12 flex w-full items-center justify-around gap-3 lg:w-1/3 lg:flex-col lg:items-center lg:justify-start">
+        <Skeleton className="size-32 rounded-full lg:size-48" />
+        <Skeleton className="h-20 w-1/3 lg:w-1/2" />
+        <Skeleton className="h-20 w-1/3 lg:h-10 lg:w-1/2 " />
+      </section>
+
+      <section className="mt-10 lg:w-1/2">
+        <Skeleton className="h-10 w-full" />
+
+        <div className="mt-6 flex flex-col gap-3 lg:mt-10">
+          {Array(5)
+            .fill(null)
+            .map((_, index) => (
+              <Skeleton key={index} className="h-32 w-full" />
+            ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ProfileLoading;

--- a/src/app/(main)/subscriptions/loading.tsx
+++ b/src/app/(main)/subscriptions/loading.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+const SubsriptionLoading = () => {
+  return (
+    <div className="mx-8 mt-14 overflow-hidden sm:mx-32">
+      <div className="flex max-w-2xl flex-col gap-3 sm:flex-row">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full sm:w-1/3" />
+      </div>
+
+      <div className=" mt-20 flex w-full max-w-2xl flex-col gap-4 overflow-hidden lg:flex-row lg:flex-wrap lg:gap-x-7 lg:gap-y-4">
+        {Array(12)
+          .fill(null)
+          .map((_, index) => (
+            <Skeleton
+              key={index}
+              className="h-14 w-full lg:w-[calc(33%-1.5rem)]"
+            />
+          ))}
+      </div>
+    </div>
+  );
+};
+
+export default SubsriptionLoading;

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -51,7 +51,7 @@ const HomePage = ({
       <main className="flex size-full flex-col pb-16">
         <Hero />
         <section className="mt-10 flex flex-col items-center gap-5 px-10 pb-20 md:px-20 lg:max-w-3xl xl:max-w-5xl">
-          <div className="flex w-full max-w-3xl flex-col items-center justify-between gap-5 sm:flex-row">
+          <div className="flex w-full max-w-2xl flex-col items-center justify-between gap-5 sm:flex-row">
             <Searchbar
               route="/"
               placeholder="Search for learning resources"

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "animate-pulse rounded-md bg-stone-300/20 dark:bg-gray-700/40",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };


### PR DESCRIPTION
This PR introduces route-level skeleton UIs throughout the application to enhance the user experience during page transitions and data fetching. Leveraging Shadcn's Skeleton component, each route group now includes a dedicated loading.tsx file to provide a consistent and context-specific loading state.

* Added loading.tsx files to relevant route groups (/home, /leaderboard, /fields, etc.)
* Implemented Shadcn UI Skeleton components in each loading.tsx for visually consistent placeholders
* Ensured that skeleton elements match the layout of their respective page UIs (e.g., text blocks, avatars, cards)
* Improved perceived performance and UX by reducing blank states during navigation